### PR TITLE
feat(tools): add Focus Assistant prototype, requirements, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Syntax & smoke checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Show Python & pip
+        run: |
+          python --version
+          pip --version
+
+      - name: Syntax check focus_assistant.py
+        run: python -m py_compile tools/focus_assistant.py
+
+      - name: Smoke test - verify files present
+        run: |
+          test -f requirements.txt || (echo "requirements.txt missing" && exit 1)
+          test -f tools/focus_assistant.py || (echo "script missing" && exit 1)
+
+      - name: Optional lint (non-fatal)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyflakes || true
+          python -m pyflakes tools/focus_assistant.py || true

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 /android/app/.*/*
+
+# Local virtual environment for Focus Assistant tests
+.venv/
+
+# Test artifacts
+task_behavior_log.csv

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "cmake.sourceDirectory": "/Users/edy/Desktop/Platform/Demo/demo_ai_even/linux"
+    "cmake.sourceDirectory": "/Users/edy/Desktop/Platform/Demo/demo_ai_even/linux",
+    "r.rpath.linux": "/usr/bin/R"
 }

--- a/README_FOCUS_ASSISTANT.md
+++ b/README_FOCUS_ASSISTANT.md
@@ -1,0 +1,33 @@
+# Focus Assistant (Prototype)
+
+A prototype companion app to interact with Even Realities G2 glasses via Bluetooth.
+
+Prerequisites
+
+- Python 3.8+ installed
+- System PortAudio (Linux: sudo apt install portaudio19-dev)
+- Bluetooth enabled and paired with the glasses
+
+Install
+
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run
+
+```
+python tools/focus_assistant.py
+```
+
+Notes
+
+- Bluetooth: Ensure device is paired and allowed for your user. Use `bluetoothctl` for pairing.
+- PortAudio: On Linux, install `portaudio19-dev` before installing `pyaudio` if pip install fails.
+- If `even-glasses` isn't available, the script falls back to a console-only stub.
+
+Data
+
+- Logs saved to `task_behavior_log.csv` in the workspace root.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+even-glasses
+speechrecognition
+pyaudio
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ even-glasses
 speechrecognition
 pyaudio
 pandas
+pytest
+pytest-mock

--- a/tests/test_focus_assistant_unit.py
+++ b/tests/test_focus_assistant_unit.py
@@ -1,0 +1,72 @@
+import os
+import csv
+import tempfile
+from tools.focus_assistant import FocusAssistant, DATA_FILE, FACILITATORS
+
+
+def test_suggest_facilitator_matches():
+    app = FocusAssistant()
+    assert app.suggest_facilitator('distracting thoughts about dinner') == FACILITATORS['distracting thoughts']
+    assert app.suggest_facilitator('I feel fatigue') == FACILITATORS['fatigue']
+    assert app.suggest_facilitator('completely unknown thing') == FACILITATORS['default']
+
+
+def test_log_behavior_creates_csv(tmp_path):
+    # Change data file to a temp path for this test
+    tmp_file = tmp_path / 'tmp_log.csv'
+    try:
+        # monkeypatch the module-level DATA_FILE variable
+        import importlib, tools.focus_assistant as fa
+        importlib.reload(fa)
+        fa.DATA_FILE = str(tmp_file)
+
+        app = FocusAssistant()
+        app.log_behavior('On Task', 'Focused', 'None')
+
+        assert tmp_file.exists()
+        with open(tmp_file, newline='') as f:
+            r = csv.DictReader(f)
+            rows = list(r)
+            assert len(rows) == 1
+            assert rows[0]['status'] == 'On Task'
+    finally:
+        if tmp_file.exists():
+            tmp_file.unlink()
+
+
+def test_run_cycle_off_task(monkeypatch, tmp_path):
+    # Simulate voice responses: 'off task' -> 'distracting thoughts'
+    responses = iter(['off task', 'distracting thoughts'])
+
+    app = FocusAssistant()
+
+    # force data file into tmp path
+    import importlib, tools.focus_assistant as fa
+    importlib.reload(fa)
+    fa.DATA_FILE = str(tmp_path / 'log.csv')
+
+    monkeypatch.setattr(app, 'listen_to_voice', lambda: next(responses, None))
+    # run a single cycle
+    app.run_cycle()
+
+    # The CSV should contain 'Off Task'
+    assert os.path.exists(fa.DATA_FILE)
+    with open(fa.DATA_FILE) as f:
+        lines = f.read()
+        assert 'Off Task' in lines
+
+
+def test_run_cycle_on_task(monkeypatch, tmp_path):
+    # Simulate voice response: 'on task'
+    app = FocusAssistant()
+
+    import importlib, tools.focus_assistant as fa
+    importlib.reload(fa)
+    fa.DATA_FILE = str(tmp_path / 'log.csv')
+
+    monkeypatch.setattr(app, 'listen_to_voice', lambda: 'on task')
+    app.run_cycle()
+
+    assert os.path.exists(fa.DATA_FILE)
+    with open(fa.DATA_FILE) as f:
+        assert 'On Task' in f.read()

--- a/tools/focus_assistant.py
+++ b/tools/focus_assistant.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Focus Assistant prototype for Even Realities G2 glasses.
+
+This is the full prototype provided by the user, adapted into a runnable
+Python module. It attempts to connect to Even G2 glasses via the
+even_glasses wrapper and uses the microphone for a short voice-driven
+interaction loop.
+
+Note: This is a prototype — tweak for your environment and library API.
+"""
+import time
+import datetime
+import pandas as pd
+import speech_recognition as sr
+
+try:
+    from even_glasses import EvenGlasses
+except Exception:
+    # Provide a lightweight stub if the even_glasses package is not present.
+    class EvenGlasses:
+        def connect(self):
+            return False
+
+        def send_text(self, text: str):
+            print("[GLASSES]", text)
+
+# --- Configuration ---
+FACILITATORS = {
+    "distracting thoughts": "Try the '5-4-3-2-1' grounding technique.",
+    "negative emotion": "Take 3 deep breaths and name the emotion.",
+    "random task": "Write it on a sticky note and return to focus.",
+    "fatigue": "Stand up and stretch for 60 seconds.",
+    "default": "Remember your goal. You can do this."
+}
+
+DATA_FILE = "task_behavior_log.csv"
+
+
+class FocusAssistant:
+    def __init__(self):
+        self.glasses = EvenGlasses()
+        self.recognizer = sr.Recognizer()
+        self.is_running = True
+
+    def connect(self):
+        print("Scanning for Even G2 glasses...")
+        if self.glasses.connect():
+            print("Connected to G2 Glasses!")
+            self.glasses.send_text("Focus Assistant\nConnected")
+        else:
+            print("Could not find glasses. Running in text-only mode.")
+
+    def listen_to_voice(self):
+        """Listens for a short phrase via microphone."""
+        try:
+            with sr.Microphone() as source:
+                print("Listening...")
+                self.recognizer.adjust_for_ambient_noise(source, duration=0.5)
+                audio = self.recognizer.listen(source, timeout=5)
+                text = self.recognizer.recognize_google(audio).lower()
+                return text
+        except (sr.UnknownValueError, sr.WaitTimeoutError):
+            return None
+
+    def log_behavior(self, status, note, facilitator_used):
+        entry = {
+            "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "status": status,
+            "note": note,
+            "facilitator": facilitator_used
+        }
+
+        df = pd.DataFrame([entry])
+        try:
+            df.to_csv(DATA_FILE, mode='a', header=not pd.io.common.file_exists(DATA_FILE), index=False)
+        except OSError:
+            df.to_csv(DATA_FILE, mode='a', header=True, index=False)
+
+        print(f"LOGGED: {status} - {note}")
+
+    def suggest_facilitator(self, note):
+        for key in FACILITATORS:
+            if key in note:
+                return FACILITATORS[key]
+        return FACILITATORS["default"]
+
+    def run_cycle(self):
+        self.glasses.send_text("Status Check:\nOn Task or Off Task?")
+        print("\nAssistant: Are you 'On Task' or 'Off Task'?")
+
+        command = self.listen_to_voice()
+
+        if not command:
+            self.glasses.send_text("Didn't hear you.\nTry again.")
+            return
+
+        if "off task" in command:
+            self.glasses.send_text("Why off task?\n(Briefly state reason)")
+            print("Assistant: Why? (e.g., 'Distracting thoughts', 'Negative emotion')")
+
+            reason = self.listen_to_voice() or "Unknown"
+            suggestion = self.suggest_facilitator(reason)
+            self.glasses.send_text(f"Strategy:\n{suggestion}")
+            print(f"Strategy Suggestion: {suggestion}")
+            self.log_behavior("Off Task", reason, suggestion)
+            time.sleep(4)
+
+        elif "on task" in command:
+            self.glasses.send_text("Great job!\nKeep flowing.")
+            self.log_behavior("On Task", "Focused", "None")
+
+        elif "exit" in command:
+            self.is_running = False
+            self.glasses.send_text("Assistant\nDisconnected")
+
+    def start(self):
+        self.connect()
+        while self.is_running:
+            try:
+                input("Press Enter to log status (or Ctrl+C to quit)...")
+                self.run_cycle()
+            except KeyboardInterrupt:
+                print("Shutting down.")
+                self.is_running = False
+
+
+def main():
+    app = FocusAssistant()
+    app.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_focus_assistant.py
+++ b/tools/test_focus_assistant.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Simple non-interactive smoke test for FocusAssistant.
+
+This test avoids microphone input and exercises internal logic only.
+"""
+from tools.focus_assistant import FocusAssistant, DATA_FILE
+import os
+
+
+def run():
+    # Ensure we start with a clean log file
+    if os.path.exists(DATA_FILE):
+        os.remove(DATA_FILE)
+
+    app = FocusAssistant()
+
+    # Connect should fall back to text-only stub
+    app.connect()
+
+    # Test suggestion lookup
+    reason = "I have distracting thoughts about dinner"
+    suggestion = app.suggest_facilitator(reason)
+    assert "5-4-3-2-1" in suggestion or suggestion == app.suggest_facilitator(reason)
+
+    # Log a behavior and verify CSV created
+    app.log_behavior("Off Task", reason, suggestion)
+    assert os.path.exists(DATA_FILE), "Log file not created"
+
+    print("TEST OK — focus assistant logic exercised successfully")
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
Adds a Python-based Focus Assistant prototype, requirements, README, and CI smoke tests to help prototype Even Realities companion apps.\n\nFiles added:\n- tools/focus_assistant.py\n- requirements.txt\n- README_FOCUS_ASSISTANT.md\n- .github/workflows/ci.yml\n\nSmoke tests verify syntax and presence of key files.\n